### PR TITLE
Add initial `ghci` config. file

### DIFF
--- a/.ghci/ghci.conf
+++ b/.ghci/ghci.conf
@@ -1,0 +1,3 @@
+# A config. file for the ghci environment
+
+:set prompt "λ> "


### PR DESCRIPTION
This **PR** adds the initial `ghci` config. file at ` ~/.ghc/ghci.conf`.

Closes #12 