### PR TITLE
Enhancement: LSP Configuration for `Haskell` in `Noevim`

### DIFF
--- a/.config/nvim/coc-settings.json
+++ b/.config/nvim/coc-settings.json
@@ -1,0 +1,29 @@
+{
+  "languageserver": {
+    "haskell": {
+      "command": "haskell-language-server-wrapper",
+      "args": [
+        "--lsp"
+      ],
+      "rootPatterns": [
+        ".stack.yaml",
+        ".hie-bios",
+        "BUILD.bazel",
+        "cabal.config",
+        "package.yaml"
+      ],
+      "filetypes": [
+        "hs",
+        "lhs",
+        "haskell"
+      ],
+      "initializationOptions": {
+        "languageServerHaskell": {
+          "hlintOn": true,
+          "maxNumberOfProblems": 10,
+          "completionSnippetsOn": true
+        }
+      }
+    }
+  }
+}

--- a/.config/nvim/plugins.vim
+++ b/.config/nvim/plugins.vim
@@ -29,6 +29,7 @@ Plug 'kwakzalver/duckytype.nvim'
 Plug 'nvim-lua/plenary.nvim'
 Plug 'nvim-telescope/telescope.nvim', { 'tag': '0.1.2' }
 Plug 'nvim-treesitter/nvim-treesitter', {'do': ':TSUpdate'}
+Plug 'neovimhaskell/haskell-vim'
 
 " ----- 8< ----- 8< ----- 8< ----- 8< -----
 


### PR DESCRIPTION
## Enhancement: LSP Configuration for `Haskell` in `Neovim`

This **PR** adds the changes to support **LSP** for `Haskell` in my current configuration in `nvim`.

Resolves #17 